### PR TITLE
Typing fixes to make mypy happy

### DIFF
--- a/object_tracker/__init__.py
+++ b/object_tracker/__init__.py
@@ -58,7 +58,7 @@ This source code is licensed under the BSD-style license found in the LICENSE fi
 
 import inspect
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .exceptions import InitialStateMissingException, InvalidChangeLogOperationException
 from .changelog import Entry, ChangeLog
@@ -107,11 +107,12 @@ class TrackerMixin:
         super().__init__(*args, **kwargs)
         logger.debug(f"Tracker initialized for {self}")
 
-    def __track_changes(self, attr, value, tracker=None) -> None:
+    def __track_changes(self, attr, value) -> None:
         if attr == self.tracker_attr:
             return
 
-        tracker: Tracker = getattr(self, self.tracker_attr, None)
+        tracker: Optional[Tracker] = getattr(self, self.tracker_attr, None)
+
         if tracker is None:
             return None
 
@@ -132,13 +133,13 @@ class TrackerMixin:
 
     def __setitem__(self, attr, value) -> None:
         self.__track_changes(attr, value)
-        super().__setitem__(attr, value)
+        super().__setitem__(attr, value)  # type: ignore
 
 
 def track(
     *attributes: List[str],
-    observers: List[ObserverType] = None,
-    attribute_observer_map: Dict[str, List[ObserverType]] = None,
+    observers: Optional[List[ObserverType]] = None,
+    attribute_observer_map: Optional[Dict[str, List[ObserverType]]] = None,
     auto_notify: bool = True,
     stack_trace: bool = True,
     tracker_attribute: str = 'tracker',

--- a/object_tracker/changelog.py
+++ b/object_tracker/changelog.py
@@ -49,7 +49,7 @@ class Entry(namedtuple('Entry', ['attr', 'old', 'new', 'timestamp', 'stack'])):
     """
     The Entry class is a named tuple that represents a single log entry in the ChangeLog.
     """
-    def __new__(cls, attr, old, new, stack: List[Frame] = None):
+    def __new__(cls, attr, old, new, stack: Optional[List[Frame]] = None):
         if stack:
             stack = [Frame(frame) for frame in stack]
 
@@ -132,7 +132,7 @@ class ChangeLog:
     def __iter__(self):
         return iter(self.log)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> List[dict]:
         return [entry.to_dict() for entry in self.log]
     
     def reset_buffer(self):

--- a/object_tracker/changelog.py
+++ b/object_tracker/changelog.py
@@ -177,7 +177,7 @@ class ChangeLog:
         eg: obj.exclude('name').all()
         """
         if not attrs:
-            return InvalidChangeLogOperationException("exclude method needs atleast one attribute")
+            raise InvalidChangeLogOperationException("exclude method needs atleast one attribute")
         return self.apply_filters(attrs, True, changes_only)
     
     def first(self) -> Optional[Entry]:

--- a/object_tracker/tracker.py
+++ b/object_tracker/tracker.py
@@ -7,7 +7,7 @@ This source code is licensed under the BSD-style license found in the LICENSE fi
 
 import logging
 from copy import deepcopy
-from typing import Dict, List
+from typing import Dict, List, Any, Optional
 
 from object_tracker.exceptions import InitialStateMissingException
 from object_tracker.changelog import ChangeLog
@@ -42,10 +42,10 @@ class Tracker:
 
     def __init__(
         self,
-        initial_state: any = None,
-        attributes: List[str] = None,
-        observers: List[ObserverType] = None,
-        attribute_observer_map: Dict[str, List[ObserverType]] = None,
+        initial_state: Any = None,
+        attributes: Optional[List[str]] = None,
+        observers: Optional[List[ObserverType]] = None,
+        attribute_observer_map: Optional[Dict[str, List[ObserverType]]] = None,
         auto_notify: bool = True,
         stack_trace: bool = True,
         changes_only: bool = False,
@@ -145,7 +145,7 @@ class Tracker:
         self.initial_state = deepcopy(obj)
         logger.debug(f"Initial state set for {self}")
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> List[dict]:
         """
         Returns the log as a dictionary
         """


### PR DESCRIPTION
Hey! I fixed some typing issues found by mypy (mostly missing Optional), and added py.typed file (like in PEP 561) to mark library as typed and allow mypy to perform typechecks